### PR TITLE
Fixed duplicate entries in nm and utils

### DIFF
--- a/NetworkManager.go
+++ b/NetworkManager.go
@@ -45,18 +45,6 @@ type NetworkManager interface {
 	// connection["802-11-wireless-security"]["psk"] = password
 	AddAndActivateWirelessConnection(connection map[string]map[string]interface{}, device Device, accessPoint AccessPoint) (ac ActiveConnection, err error)
 
-	// AddAndActivateWirelessConnection adds a new connection profile to the network device it has been
-	// passed. It then activates the connection to the passed access point. The first paramter contains
-	// additional information for the connection (most propably the credentials).
-	// Example contents for connection are:
-	// connection := make(map[string]map[string]interface{})
-	// connection["802-11-wireless"] = make(map[string]interface{})
-	// connection["802-11-wireless"]["security"] = "802-11-wireless-security"
-	// connection["802-11-wireless-security"] = make(map[string]interface{})
-	// connection["802-11-wireless-security"]["key-mgmt"] = "wpa-psk"
-	// connection["802-11-wireless-security"]["psk"] = password
-	AddAndActivateWirelessConnection(connection map[string]map[string]interface{}, device Device, accessPoint AccessPoint) (ac ActiveConnection, err error)
-
 	Subscribe() <-chan *dbus.Signal
 	Unsubscribe()
 
@@ -128,22 +116,6 @@ func (n *networkManager) AddAndActivateWirelessConnection(connection map[string]
 	var opath2 dbus.ObjectPath
 
 	err = n.call2(&opath1, &opath2, NetworkManagerAddAndActivateConnection, connection, d.GetPath(), ap.GetPath())
-	if err != nil {
-		return
-	}
-
-	ac, err = NewActiveConnection(opath2)
-	if err != nil {
-		return
-	}
-	return
-}
-
-func (n *networkManager) AddAndActivateWirelessConnection(connection map[string]map[string]interface{}, d Device, ap AccessPoint) (ac ActiveConnection, err error) {
-	var opath1 dbus.ObjectPath
-	var opath2 dbus.ObjectPath
-
-	err = n.callError2(&opath1, &opath2, NetworkManagerAddAndActivateConnection, connection, d.GetPath(), ap.GetPath())
 	if err != nil {
 		return
 	}

--- a/utils.go
+++ b/utils.go
@@ -38,10 +38,6 @@ func (d *dbusBase) call2(value1 interface{}, value2 interface{}, method string, 
 	return d.obj.Call(method, 0, args...).Store(value1, value2)
 }
 
-func (d *dbusBase) callError2(value1 interface{}, value2 interface{}, method string, args ...interface{}) error {
-	return d.obj.Call(method, 0, args...).Store(value1, value2)
-}
-
 func (d *dbusBase) subscribe(iface, member string) {
 	rule := fmt.Sprintf("type='signal',interface='%s',path='%s',member='%s'",
 		iface, d.obj.Path(), NetworkManagerInterface)


### PR DESCRIPTION
After the latest merge there was a duplicate entry of AddAndActivateWirelessConnection in NetworkManager.go
which has been removed. There was also duplicate functions call2 and
callError2 in utils.go. The duplicate of AddAndActivateWirelessConnection referenced
callError2, and both of these duplicates has been removed.